### PR TITLE
Render `NULL`s in query results

### DIFF
--- a/inputs/demo-null.txt
+++ b/inputs/demo-null.txt
@@ -1,0 +1,10 @@
+# Clean up from last time.
+setup: DROP TABLE IF EXISTS t1;
+setup: CREATE TABLE t1 (v INT);
+
+# Insert both NULL and non-NULL values.
+setup: INSERT INTO t1 VALUES (1);
+setup: INSERT INTO t1 VALUES (NULL);
+
+# Report the final results.
+setup: SELECT * from t1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,9 +317,10 @@ fn sql_render(row: &postgres::Row, idx: usize, sql_type: &Type) -> String {
 ///
 /// This is a separate function for convenience because the caller can easily
 /// specify what Rust type they want to use to convert the value.
-fn sql_render_value<T: ToString>(t: Result<T, postgres::Error>) -> String {
+fn sql_render_value<T: ToString>(t: Result<Option<T>, postgres::Error>) -> String {
     match t {
-        Ok(t) => t.to_string(),
+        Ok(Some(t)) => t.to_string(),
+        Ok(None) => "NULL".to_string(),
         Err(e) => format!("<bad conversion: {}>", InlineErrorChain::new(&e)),
     }
 }


### PR DESCRIPTION
I was using sqldance as a fancy SQL shell and bumped into a query that returned NULL-valued columns. Without the patch on this PR, running the new `demo-null.txt` emits:

```
conn "setup": connecting to postgresql://root@percy:26257/defaultdb?sslmode=disable ... connected
conn "setup": executing: "DROP TABLE IF EXISTS t1;"
conn "setup": success (rows returned: 0)

conn "setup": executing: "CREATE TABLE t1 (v INT);"
conn "setup": success (rows returned: 0)

conn "setup": executing: "INSERT INTO t1 VALUES (1);"
conn "setup": success (rows returned: 0)

conn "setup": executing: "INSERT INTO t1 VALUES (NULL);"
conn "setup": success (rows returned: 0)

conn "setup": executing: "SELECT * from t1;"
conn "setup": success (rows returned: 2)
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ v                                                                                                        │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ 1                                                                                                        │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ <bad conversion: error deserializing column 0: a Postgres value was `NULL`: a Postgres value was `NULL`> │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

With this patch, we get:

```
conn "setup": connecting to postgresql://root@percy:26257/defaultdb?sslmode=disable ... connected
conn "setup": executing: "DROP TABLE IF EXISTS t1;"
conn "setup": success (rows returned: 0)

conn "setup": executing: "CREATE TABLE t1 (v INT);"
conn "setup": success (rows returned: 0)

conn "setup": executing: "INSERT INTO t1 VALUES (1);"
conn "setup": success (rows returned: 0)

conn "setup": executing: "INSERT INTO t1 VALUES (NULL);"
conn "setup": success (rows returned: 0)

conn "setup": executing: "SELECT * from t1;"
conn "setup": success (rows returned: 2)
┌──────┐
│ v    │
├──────┤
│ 1    │
├──────┤
│ NULL │
└──────┘
```